### PR TITLE
fix: Taro Vue小程序基础库大于2.24.1图片无法渲染问题

### DIFF
--- a/packages/taro/vue/LuckyWheel.vue
+++ b/packages/taro/vue/LuckyWheel.vue
@@ -44,6 +44,7 @@
 
 <script>
 import Taro from '@tarojs/taro'
+import { markRaw } from 'vue'
 import { LuckyWheel as Wheel } from 'lucky-canvas'
 import { changeUnits, resolveImage, getFlag, getImage } from '../utils'
 export default {
@@ -157,7 +158,7 @@ export default {
         }
         if (!res[0] || !res[0].node) return console.error('lucky-canvas 获取不到 canvas 标签')
         const { node, width, height } = res[0]
-        const canvas = this.canvas = node
+        const canvas = this.canvas = markRaw ? markRaw(node) : node
         const ctx = this.ctx = canvas.getContext('2d')
         const dpr = this.dpr = Taro.getSystemInfoSync().pixelRatio
         canvas.width = width * dpr


### PR DESCRIPTION
通过标记源数据为非响应性数据，避免被Proxy代理并污染

关联ISSUES:
#322 #301